### PR TITLE
fix(*): fix network module status problem

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -728,7 +728,7 @@ downloads:
     - k8s-cluster
 
   calicoctl:
-    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
+    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' or kube_network_plugin == 'bd-calico' }}"
     file: true
     version: "{{ calico_ctl_version }}"
     dest: "{{ local_release_dir }}/calicoctl"
@@ -741,7 +741,7 @@ downloads:
     - k8s-cluster
 
   calico_node:
-    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
+    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' or kube_network_plugin == 'bd-calico' }}"
     container: true
     repo: "{{ calico_node_image_repo }}"
     tag: "{{ calico_node_image_tag }}"
@@ -750,7 +750,7 @@ downloads:
     - k8s-cluster
 
   calico_cni:
-    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
+    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' or kube_network_plugin == 'bd-calico' }}"
     container: true
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
@@ -759,7 +759,7 @@ downloads:
     - k8s-cluster
 
   calico_policy:
-    enabled: "{{ enable_network_policy and kube_network_plugin in ['calico', 'canal'] }}"
+    enabled: "{{ enable_network_policy and kube_network_plugin in ['calico', 'canal', 'bd-calico'] }}"
     container: true
     repo: "{{ calico_policy_image_repo }}"
     tag: "{{ calico_policy_image_tag }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What type of PR is this?**
/kind bug
/area release

**What this PR does / why we need it**:
因为网络模块的修改，是新增网络模块的方式更新的。在修改中，遗漏了下载地址状态判断的修改。

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @bbbmj @hanxueluo @angao 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Repair the network module status judgment
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
 
