### PR TITLE
feat(*): Allow independent deployment of etcd nodes

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -140,5 +140,5 @@
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: self-hosted, when: "inventory_hostname in groups['kube-master'] and containeros_cluster|bool", tags: self-hosted }
+    - { role: self-hosted, when: "containeros_cluster|bool", tags: self-hosted }
 

--- a/roles/self-hosted/tasks/main.yml
+++ b/roles/self-hosted/tasks/main.yml
@@ -3,6 +3,8 @@
   file:
     name: "{{ self_hosted_config_dir }}"
     state: directory
+  when:
+    - inventory_hostname in groups['kube-master']
 
 - name: Generate COS namespaces yaml
   template:
@@ -10,6 +12,7 @@
     dest: "{{ self_hosted_config_dir }}/cos-system-ns.yml"
   when:
     - cos_running_namespaces not in ["default", "kube-system", "kube-node-lease", "kube-public"]
+    - inventory_hostname in groups['kube-master']
 
 - name: Create COS namespaces
   kube:
@@ -30,16 +33,28 @@
 # Add label on master node
 - name: Add label on master node
   shell: |
-    kubectl label node {{ inventory_hostname }} {{ item }}
+    {{ bin_dir }}/kubectl label node {{ inventory_hostname }} {{ item }} --overwrite
   with_items:
     - node-role.release.containeros.dev/primary-master=true
-    - node-role.release.containeros.dev/primary-etcd=true
   register: label_status
   until: label_status.rc == 0
   retries: 30
   delay: 10
   when:
     - inventory_hostname in groups['kube-master'][0]
+
+- name: Add label on master node
+  shell: |
+    {{ bin_dir }}/kubectl label node {{ inventory_hostname }} {{ item }} --overwrite
+  with_items:
+    - node-role.release.containeros.dev/primary-etcd=true
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  register: label_status
+  until: label_status.rc == 0
+  retries: 30
+  delay: 10
+  when:
+    - inventory_hostname in groups['etcd'][0]
 
 # Ensure self-hosted config dir exist
 - name: Ensure self-hosted config dir exist
@@ -49,6 +64,8 @@
     owner: root
     group: root
     mode: 0o755
+  when:
+    - inventory_hostname in groups['kube-master']
 
 # Read ssh certs and create secret
 - name: Read ssh private key
@@ -80,7 +97,9 @@
   copy:
     src: "{{ image_registry_signed_certificate }}"
     dest: "{{ kube_config_dir }}/registry-ca.crt"
-  when: image_registry_ca_self_sign
+  when: 
+    - image_registry_ca_self_sign
+    - inventory_hostname in groups['kube-master']
 
 - name: Create secret for image registry ca cert
   shell: |
@@ -194,6 +213,8 @@
     cat {{ local_vip_kubeconfig_file }} | base64 | tr -d "\n"
   delegate_to: localhost
   register: local_kubeconfig_base64
+  when:
+    - inventory_hostname in groups['kube-master']
 
 - name: Generate cluster crd
   template:
@@ -216,6 +237,36 @@
   when:
     - not deploy_control_cluster|bool
     - inventory_hostname in groups['kube-master'][0]
+
+- name: Fetch etcd certs
+  fetch:
+    src: "{{ etcd_cert_dir }}/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    flat: true
+    validate_checksum: no
+  with_items:
+    - src: "admin-{{ inventory_hostname }}.pem"
+      dest: "admin-{{ groups['kube-master'][0] }}.pem"
+    - src: "admin-{{ inventory_hostname }}-key.pem"
+      dest: "admin-{{ groups['kube-master'][0] }}-key.pem"
+  when:
+    - inventory_hostname in groups['etcd'][0]
+    - inventory_hostname not in groups['kube-master']
+
+- name: Sync etcd certs
+  copy:
+    src: "/tmp/{{ item.dest }}"
+    dest: "{{ etcd_cert_dir }}/{{ item.dest }}"
+    force: true
+  with_items:
+    - src: "admin-{{ inventory_hostname }}.pem"
+      dest: "admin-{{ groups['kube-master'][0] }}.pem"
+    - src: "admin-{{ inventory_hostname }}-key.pem"
+      dest: "admin-{{ groups['kube-master'][0] }}-key.pem"
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  when:
+    - inventory_hostname in groups['etcd'][0]
+    - inventory_hostname not in groups['kube-master']
 
 - name: Create etcd tls secret
   shell: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What type of PR is this?**
/kind feature
/area release

**What this PR does / why we need it**:
优化 etcd 节点独立部署时的 label 以及 tls secret 的创建

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @muzi502 @cbsfly 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow independent deployment of etcd nodes
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
 
